### PR TITLE
fix effects teardown

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -41,6 +41,8 @@ const main = async () => {
     console.log("server listening to port", port)
   })
 
-  metaHotTeardown(() => server.close())
+  metaHotTeardown(import.meta.hot, () => {
+    server.close()
+  })
 }
 main()

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -11,7 +11,6 @@ export type MakeAppRouterParams = {
   userService: UserService
   wishListService: WishListService
 }
-
 export const makeAppRouter = ({
   userService,
   wishListService,

--- a/src/backend/utils/metaHotTeardown.ts
+++ b/src/backend/utils/metaHotTeardown.ts
@@ -5,9 +5,15 @@
 // teardown the side effect that main() has.
 // https://github.com/vitest-dev/vitest/issues/2334
 
-export const metaHotTeardown = (teardown: () => unknown) => {
-  if (import.meta.hot) {
-    import.meta.hot.on("vite:beforeFullReload", teardown);
-    import.meta.hot.dispose(teardown);
+import { ViteHotContext } from "vite/types/hot"
+
+export const metaHotTeardown = (
+  importMetaHot: ViteHotContext | undefined,
+  teardown: () => unknown,
+) => {
+  if (importMetaHot) {
+    importMetaHot.on("vite:beforeFullReload", teardown)
+    importMetaHot.dispose(teardown)
+    importMetaHot.accept(teardown)
   }
-};
+}


### PR DESCRIPTION
This should fix the problem where saving any backend file would cause the backend to say "Error, 4000 something is already listening to that port".   

This problem is kind of related to HMR (hot module reloading) where vite is trying to only reload things that have changed, but not actually replace the running nodejs process.  I had this makeHotTEa method but the problem I think it is needs the import.meta.hot of the file associated with the side effect. ` import.meta.hot` seems like it's actually specific to the file, so it needs to be passed as an argument to my helper function - which then registers the cleanup method with the appropriate handles.