### PR TITLE
Fixing bundling issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist-ssr
 
 # directory where I'm storying the db locally
 storage
+
+*.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-slim
 WORKDIR /app
 
 # sqlite3 gotta be installed in the context of the arch....
-RUN npm install sqlite3
+RUN npm install sqlite3@5.1.7
 
 COPY ./dist/backend ./backend
 COPY ./dist/frontend ./frontend

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-pnpm build && docker-compose build
+pnpm build 
+
+docker-compose build
 
 PROJECT_NAME="wish-tree"
 TAR_FILE="$PROJECT_NAME-bundle.tar"  # Tar file name

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+pnpm build && docker-compose build
+
+PROJECT_NAME="wish-tree"
+TAR_FILE="$PROJECT_NAME-bundle.tar"  # Tar file name
+
+# Paths to files
+DOCKER_COMPOSE_FILE="docker-compose.yml"  # Path to docker-compose.yml
+IMAGES=("wishtree-server:latest")  # List of Docker images to save (provide name:tag)
+
+# Step 1: Save Docker images to a tar file
+echo "Saving Docker images..."
+for IMAGE in "${IMAGES[@]}"; do
+    docker save "$IMAGE" -o "$(basename "$IMAGE").tar"
+done
+
+# Step 2: Bundle docker-compose.yml and images into a tar archive
+echo "Creating deployment tarball..."
+tar -cf "$TAR_FILE" "$DOCKER_COMPOSE_FILE" *.tar
+
+echo "Cleanup!"
+for IMAGE in "${IMAGES[@]}"; do
+    rm "$(basename "$IMAGE").tar"
+done
+
+echo "Produced $TAR_FILE"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+# Check if required arguments are provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <user@ip>"
+    exit 1
+fi
+
+# Parameters
+SERVER="$1"  # SSH user for the server (passed as the first argument)
+SERVER_DIR="~/"  # Target directory on the server
+
+PROJECT_NAME="wish-tree"
+TAR_FILE="$PROJECT_NAME-bundle.tar"  # Tar file name
+
+# Paths to files
+
+
+ssh $SERVER << EOF
+[ ! -d "~/deployments/$PROJECT_NAME" ] && mkdir -p ~/deployments/$PROJECT_NAME
+EOF
+
+INSTALL_DIR="~/deployments/$PROJECT_NAME"
+# # ??
+# # ssh "$SERVER_USER@$SERVER_IP" "mkdir -p $INSTALL_DIR"
+
+# # Step 3: Transfer tarball to the server
+# echo "Transferring tarball to the server..."
+echo "gonna scp the $TAR_FILE to $SERVER:$INSTALL_DIR"
+scp "$TAR_FILE" "$SERVER:$INSTALL_DIR"
+
+# rm "$TAR_FILE"
+
+# Step 4: SSH into the server and handle deployment
+echo "Deploying on the server..."
+ssh "$SERVER" << EOF
+    # Go to the deployment directory
+    cd $INSTALL_DIR
+
+    # At least for may@may-pi, the user may doens't have docker permission so... sudo su
+    sudo su
+
+    if [ -f "docker-compose.yml" ] || [ -f "compose.yaml" ]; then
+        echo "Stopping containers and removing previous images"
+        docker compose down --rmi all
+    else
+        echo "No Compose file found. Skipping 'docker compose down'."
+    fi
+
+    # Untar the new deployment bundle
+    echo "Extracting deployment bundle..."
+    tar -xf "$TAR_FILE"
+
+    # Load Docker images
+    echo "Loading Docker images..."
+    for IMAGE_TAR in *.tar; do
+        echo "Loading $IMAGE_TAR"
+        docker load -i "\$IMAGE_TAR"
+    done
+
+    echo "Starting the application..."
+    docker compose up -d
+
+    # Clean up tar files
+    echo "Cleaning up tar files..."
+    rm -f ./*.tar
+EOF
+
+# Step 5: Clean up local tar files
+# echo "Cleaning up local files..."
+# rm -f *.tar "$TAR_FILE"
+
+echo "Deployment complete!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
 version: "3.8"
 
 services:
-  frontend-nginx:
+  wishtree-server:
     image: wishtree-server
     build:
       context: ./
-    # platform: linux/arm64/v8
     ports:
-      - "12347:80"
+      - "12347:4000"
+    platform: linux/arm64/v8
+    volumes:
+      - wish-tree-server-data:/data
+    restart: unless-stopped
+volumes:
+  wish-tree-server-data:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-router-dom": "^7.0.1",
-    "sqlite3": "^5.1.7",
+    "sqlite3": "5.1.7",
     "uuid": "^11.0.3",
     "vitest": "^2.1.6",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@tanstack/react-query':
     specifier: ^5.62.0
@@ -50,7 +54,7 @@ dependencies:
     specifier: ^7.0.1
     version: 7.0.1(react-dom@18.3.1)(react@18.3.1)
   sqlite3:
-    specifier: ^5.1.7
+    specifier: 5.1.7
     version: 5.1.7
   uuid:
     specifier: ^11.0.3
@@ -1149,7 +1153,7 @@ packages:
       '@types/node': 22.10.1
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1
+      ajv-formats: 3.0.1(ajv@8.13.0)
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -1802,8 +1806,10 @@ packages:
       ajv: 8.13.0
     dev: true
 
-  /ajv-formats@3.0.1:
+  /ajv-formats@3.0.1(ajv@8.13.0):
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -5458,7 +5464,3 @@ packages:
   /zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,11 +40,6 @@ export default defineConfig({
     }),
   ],
   external: [
-    // "zod",
-    // "cookie-parser",
-    // "jsonwebtoken",
-    // "bcrypt",
-    // "bcrypt-ts",
     "sqlite3",
     // Specify modules that should remain external (Node.js built-ins)
     ...builtinModules,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,12 +20,13 @@ export default defineConfig({
     sourcemap: true, // Include sourcemaps for debugging
   },
   plugins: [
-    polyfillNode(),
     typescript({
-      tsconfig: "./tsconfig.json", // Path to your tsconfig file
+      tsconfig: "./tsconfig-backend.json", // Path to your tsconfig file
     }),
     resolve({ preferBuiltins: true }),
     commonjs(), // Convert CommonJS to ES modules
+    polyfillNode(),
+
     // autoNamedExports(),
     // globals(),
     // builtin(),

--- a/src/backend/adapters/WishListAdapter.ts
+++ b/src/backend/adapters/WishListAdapter.ts
@@ -87,8 +87,9 @@ export const makeWishListStorageAdapter = (
   return {
     upsertDbWishList,
     getWishList,
-    getWishItems,
-    getWishListsByUserId: getWishListsByUserId,
+    // broken types fixed on may branch
+    getWishItems: getWishItems as any,
+    getWishListsByUserId: getWishListsByUserId as any,
     upsertWishItem,
   }
 }

--- a/src/backend/authMiddleware.ts
+++ b/src/backend/authMiddleware.ts
@@ -1,6 +1,6 @@
 // import { TRPCError } from "@trpc/server"
 import { UserService } from "./services/UserService"
-import { User } from "./models/models"
+// import { User } from "./models/models"
 import { DateTime } from "luxon"
 
 export const authMiddleware = (userService: UserService) => {
@@ -24,13 +24,12 @@ export const authMiddleware = (userService: UserService) => {
     //   })
     // }
 
-
     ctx.user = {
-      birthday: DateTime.now(), 
-      id: 'qwert',
-      name: 'test', 
-      email: 'builtbymay@gmail.com'
-    } satisfies User
+      birthday: DateTime.now(),
+      id: "qwert",
+      name: "test",
+      email: "builtbymay@gmail.com",
+    }
     return next()
   }
 }

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -2,6 +2,7 @@ import { createExpressMiddleware } from "@trpc/server/adapters/express"
 import cookieParser from "cookie-parser"
 import cors from "cors"
 import express, { Request, Response } from "express"
+import path from "path"
 import { makeAppRouter } from "src/backend/router"
 import { metaHotTeardown } from "src/backend/utils/metaHotTeardown"
 import { bootstrap } from "./bootstrap"
@@ -9,7 +10,7 @@ import { bootstrap } from "./bootstrap"
 const main = async () => {
   const app = express()
 
-  // Some cors settings to enable us to have a website hosted at :3000 calling backend at :4000 for example (cross domain)
+  // // Some cors settings to enable us to have a website hosted at :3000 calling backend at :4000 for example (cross domain)
   app.use(
     cors({
       origin: true,
@@ -20,7 +21,7 @@ const main = async () => {
 
   app.use(cookieParser())
 
-  // make the trpc appRouter - it handles all the requests
+  // // make the trpc appRouter - it handles all the requests
   const services = await bootstrap()
   const appRouter = await makeAppRouter(services)
 
@@ -34,6 +35,16 @@ const main = async () => {
       }),
     }),
   )
+
+  // when app is deployed in a container, it'll have the frontend in this directory.
+  app.get("*", (req: Request, res: Response): any => {
+    // If the request starts with "/trpc", don't serve React.
+    if (req.path.startsWith("/trpc")) {
+      return res.status(404).send({ error: "API endpoint not found" })
+    }
+
+    res.sendFile(path.join("frontend", "index.html"))
+  })
 
   const port = 4000
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -36,14 +36,18 @@ const main = async () => {
     }),
   )
 
-  // when app is deployed in a container, it'll have the frontend in this directory.
+  const pathToFrontend = "/app/frontend"
+  console.log("static serve fronted at", pathToFrontend)
+  app.use(express.static(pathToFrontend))
+
   app.get("*", (req: Request, res: Response): any => {
     // If the request starts with "/trpc", don't serve React.
     if (req.path.startsWith("/trpc")) {
       return res.status(404).send({ error: "API endpoint not found" })
     }
-
-    res.sendFile(path.join("frontend", "index.html"))
+    const pathToIndex = path.join(pathToFrontend, "index.html")
+    console.log("sendfile from", pathToIndex)
+    res.sendFile(pathToIndex)
   })
 
   const port = 4000

--- a/src/backend/vite-env.d.ts
+++ b/src/backend/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/frontend/components/forms/WishItemForm.tsx
+++ b/src/frontend/components/forms/WishItemForm.tsx
@@ -58,7 +58,9 @@ export const WishItemForm = ({ togglePopUp, wishListID }: WishItemFormType) => {
     useState("+ Upload Image")
 
   const imgPreview = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setProductImg(URL.createObjectURL(event.target.files[0]))
+    const first = event.target.files?.[0]
+    if (!first) return
+    setProductImg(URL.createObjectURL(first))
     setProductImgButtonText("Change Product Image")
   }
   const imgButtonHandler = () => {

--- a/src/frontend/components/forms/WishListForm.tsx
+++ b/src/frontend/components/forms/WishListForm.tsx
@@ -63,7 +63,9 @@ export const WishListForm = ({ closeWishListForm }: WishListFormType) => {
     useState("+ Add Cover Image")
 
   const imgPreview = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCoverImg(URL.createObjectURL(event.target.files[0]))
+    const first = event.target.files?.[0]
+    if (!first) return
+    setCoverImg(URL.createObjectURL(first))
     setCoverImgButtonText("Change Cover Image")
   }
   const imgButtonHandler = () => {

--- a/src/frontend/components/wishList/WishItem.tsx
+++ b/src/frontend/components/wishList/WishItem.tsx
@@ -21,9 +21,7 @@ export const WishItem = ({ wishItem, wishListCreater }: WishItemProp) => {
     setDropDownMenu(false)
   }
 
-  const wishItemMoreClickHandler = (
-    event: React.MouseEvent<HTMLDivElement>,
-  ) => {
+  const wishItemMoreClickHandler = (event: React.MouseEvent<SVGElement>) => {
     event.stopPropagation() // Prevent the event from propagating to the whole div
     console.log("Hi you cicked on the more options")
     setDropDownMenu(!dropDownMenu)
@@ -59,13 +57,13 @@ export const WishItem = ({ wishItem, wishListCreater }: WishItemProp) => {
             />
           )}
         </div>
-        {wishItem.imageUrl?.length > 0 && (
+        {wishItem.imageUrl?.length ? (
           <img
             {...stylex.props(styles.imgPreview)}
             src={wishItem.imageUrl}
             alt={wishItem.name}
           />
-        )}
+        ) : null}
       </div>
       <div {...stylex.props(styles.line)} />
       <div {...stylex.props(styles.name)}>{wishItem.name}</div>

--- a/src/frontend/pages/WishListPage.tsx
+++ b/src/frontend/pages/WishListPage.tsx
@@ -75,7 +75,7 @@ export const WishListPage = () => {
         <div {...stylex.props(styles.wishItemContainer)}>
           <AddWishItemButton onClickFn={addANewWish} />
 
-          {togglePopUp && (
+          {togglePopUp && wishlistid && (
             <PopUp>
               <WishItemForm
                 wishListID={wishlistid}

--- a/tsconfig-backend.json
+++ b/tsconfig-backend.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": "."
+  },
+  "include": ["src/backend"]
+}


### PR DESCRIPTION
rollup compiles our backend using various plugins.  It transpiles our source ts into js and also figures out how to bundle 3rd party dependencies.  In addition there are included deps (in node itself) which are "external" and don't need to be bundled.  rollup figures that out with the help of correct config. 

The issue I was having is I would build and it replace some imports with "require("./node.js")". But that's weird because there is no node.js file, and the corresponding backend bundle would not actually run.  That was occuring because I had the order of plugins incorrectly.  The "resolve" plugin needed to come before the "commonjs" plugin.  

In addition to that change I fixed some type issues in the frontend.